### PR TITLE
Simplified with switch in query

### DIFF
--- a/src/templates/DrupalTaxonomyTermTags.vue
+++ b/src/templates/DrupalTaxonomyTermTags.vue
@@ -5,7 +5,7 @@
     <div>All articles tagged by <strong><em>{{ getTagName }}</em></strong></div>
 
     <ul>
-      <li v-for="{ node } in getArticlesByTagName" :key="node.title">
+      <li v-for="{ node } in $page.articles.belongsTo.edges" :key="node.title">
         <a :href="node.path">{{ node.title }}</a>
       </li>
     </ul>
@@ -19,52 +19,23 @@
         const { params: { name } = {} } = this.$route
         return name
       },
-      articles() {
-        const { 
-          allDrupalNodeArticle: {
-            edges
-          } = {}
-        } = this.$page
-
-        return edges || []
-      },
-      getArticlesByTagName() {
-        return this.articles.filter((article) => {
-          let {
-            node: {
-              field_tags = []
-            } = {}
-          } = article
-
-          const allTags = field_tags.map(tag => {
-            const {
-              node: {
-                name
-              } = {}
-            } = tag
-
-            return name
-          })
-
-          return allTags.includes(this.getTagName)
-        })
-      }
     }
   }
 </script>
 
 <page-query>
-  query Articles {
-    allDrupalNodeArticle (perPage:100) {
-      edges {
-        node {
-          id,
-          title,
-          path,
-          field_tags {
-            node {
-              id,
-              name
+  query Articles($path: String!, $page: Int) {
+    articles: drupalTaxonomyTermTags(path: $path) {
+      belongsTo (perPage: 1000, page: $page) @paginate {
+        pageInfo {
+          totalPages
+          currentPage
+        }
+        edges {
+          node {
+            ... on DrupalNodeArticle {
+              title
+              path
             }
           }
         }


### PR DESCRIPTION
This relates to https://github.com/matt-e-king/gridsome-starter-drupal/issues/1 opened yesterday. By using fragments with the query, you can significantly simplify the code and you could opt to show all nodes or some (and add pagination if you wanted). I'm basing this with 1000 nodes per term page (which would be pretty impressive for a starter blog).